### PR TITLE
Store entities and links directly in configured store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# netscrape: Go module for building networks from arbitrary data sources
+# netscrape: build networks from arbitrary data sources
+
+`netscrape` is a `Go` module for building networks from arbitrary data sources.
 
 [![Build Status](https://github.com/milosgajdos/netscrape/workflows/CI/badge.svg)](https://github.com/milosgajdos/netscrape/actions?query=workflow%3ACI)
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/milosgajdos/netscrape)

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -94,16 +94,16 @@ type NodeRemover interface {
 	RemoveNode(context.Context, uuid.UID) error
 }
 
-// NodeLinker links two nodes in graph.
-type NodeLinker interface {
+// Linker links two nodes in graph.
+type Linker interface {
 	// Link links two nodes and returns the new edge.
 	Link(ctx context.Context, from, to uuid.UID, opts ...Option) (Edge, error)
 }
 
-// LinkRemover removes link between two Nodes.
-type LinkRemover interface {
-	// RemoveEdge removes link(s) from graph.
-	RemoveLink(ctx context.Context, from, to uuid.UID) error
+// Unlinker removes link between two Nodes.
+type Unlinker interface {
+	// Unlink removes link from graph.
+	Unlink(ctx context.Context, from, to uuid.UID) error
 }
 
 // Graph is a graph of entities.

--- a/pkg/graph/memory/memory.go
+++ b/pkg/graph/memory/memory.go
@@ -8,6 +8,6 @@ type Graph interface {
 	graph.SubGrapher
 	graph.NodeAdder
 	graph.NodeRemover
-	graph.NodeLinker
-	graph.LinkRemover
+	graph.Linker
+	graph.Unlinker
 }

--- a/pkg/graph/memory/wug.go
+++ b/pkg/graph/memory/wug.go
@@ -224,8 +224,8 @@ func (g *WUG) Edges(ctx context.Context) ([]graph.Edge, error) {
 	return edges, nil
 }
 
-// RemoveLink removes link between two nodes.
-func (g *WUG) RemoveLink(ctx context.Context, from, to uuid.UID) error {
+// Unlink removes link between two nodes.
+func (g *WUG) Unlink(ctx context.Context, from, to uuid.UID) error {
 	f, ok := g.nodes[from.Value()]
 	if !ok {
 		return nil

--- a/pkg/graph/memory/wug_test.go
+++ b/pkg/graph/memory/wug_test.go
@@ -226,7 +226,7 @@ func TestWUGLinkGetRemoveEdge(t *testing.T) {
 	}
 
 	// remove edge between previously linked nodes which are still present in the graph
-	if err := g.RemoveLink(context.TODO(), n1.UID(), n2.UID()); err != nil {
+	if err := g.Unlink(context.TODO(), n1.UID(), n2.UID()); err != nil {
 		t.Errorf("failed removing edge between %s and %s: %v", n1.UID(), n2.UID(), err)
 	}
 
@@ -235,11 +235,11 @@ func TestWUGLinkGetRemoveEdge(t *testing.T) {
 	}
 
 	// remoe edge between non-existen nodes should return nil
-	if err := g.RemoveLink(context.TODO(), nodeX.UID(), n1.UID()); err != nil {
+	if err := g.Unlink(context.TODO(), nodeX.UID(), n1.UID()); err != nil {
 		t.Errorf("failed removing edge between %s and %s: %v", nodeX.UID(), n1.UID(), err)
 	}
 
-	if err := g.RemoveLink(context.TODO(), n1.UID(), nodeX.UID()); err != nil {
+	if err := g.Unlink(context.TODO(), n1.UID(), nodeX.UID()); err != nil {
 		t.Errorf("failed removing edge between %s and %s: %v", nodeX.UID(), n1.UID(), err)
 	}
 }

--- a/pkg/store/memory/memory.go
+++ b/pkg/store/memory/memory.go
@@ -8,6 +8,7 @@ import (
 	"github.com/milosgajdos/netscrape/pkg/graph/memory"
 	"github.com/milosgajdos/netscrape/pkg/query"
 	"github.com/milosgajdos/netscrape/pkg/store"
+	"github.com/milosgajdos/netscrape/pkg/uuid"
 )
 
 // Store is in-memory store.
@@ -52,14 +53,14 @@ func (m *Store) Add(ctx context.Context, e store.Entity, opts ...store.Option) e
 	return m.g.AddNode(ctx, n)
 }
 
-// Link links two entities in store.
-func (m *Store) Link(ctx context.Context, from, to store.Entity, opts ...store.Option) error {
-	aopts := store.Options{}
+// Link links entities with given UIDs in store.
+func (m *Store) Link(ctx context.Context, from, to uuid.UID, opts ...store.Option) error {
+	lopts := store.Options{}
 	for _, apply := range opts {
-		apply(&aopts)
+		apply(&lopts)
 	}
 
-	if _, err := m.g.Link(ctx, from.UID(), to.UID(), graph.WithAttrs(aopts.Attrs)); err != nil {
+	if _, err := m.g.Link(ctx, from, to, graph.WithAttrs(lopts.Attrs)); err != nil {
 		return err
 	}
 
@@ -68,22 +69,22 @@ func (m *Store) Link(ctx context.Context, from, to store.Entity, opts ...store.O
 
 // Delete deletes e from memory store.
 func (m *Store) Delete(ctx context.Context, e store.Entity, opts ...store.Option) error {
-	aopts := store.Options{}
+	dopts := store.Options{}
 	for _, apply := range opts {
-		apply(&aopts)
+		apply(&dopts)
 	}
 
 	return m.g.RemoveNode(ctx, e.UID())
 }
 
-// Unlink two entities in store.
-func (m *Store) Unlink(ctx context.Context, from, to store.Entity, opts ...store.Option) error {
-	aopts := store.Options{}
+// Unlink two entities with given UIDs in store.
+func (m *Store) Unlink(ctx context.Context, from, to uuid.UID, opts ...store.Option) error {
+	ulopts := store.Options{}
 	for _, apply := range opts {
-		apply(&aopts)
+		apply(&ulopts)
 	}
 
-	if err := m.g.RemoveLink(ctx, from.UID(), to.UID()); err != nil {
+	if err := m.g.Unlink(ctx, from, to); err != nil {
 		return err
 	}
 

--- a/pkg/store/memory/memory_test.go
+++ b/pkg/store/memory/memory_test.go
@@ -122,7 +122,7 @@ func TestLink(t *testing.T) {
 		t.Fatalf("failed storing node %s: %v", e2.UID(), err)
 	}
 
-	if err := m.Link(context.TODO(), e1, e2); err != nil {
+	if err := m.Link(context.TODO(), e1.UID(), e2.UID()); err != nil {
 		t.Errorf("failed linking %v to %v: %v", e1.UID(), e2.UID(), err)
 	}
 
@@ -141,7 +141,7 @@ func TestLink(t *testing.T) {
 		t.Errorf("expected links: %d, got: %d", expCount, linkCount)
 	}
 
-	if err := m.Unlink(context.TODO(), e1, e2); err != nil {
+	if err := m.Unlink(context.TODO(), e1.UID(), e2.UID()); err != nil {
 		t.Errorf("failed linking %v to %v: %v", e1.UID(), e2.UID(), err)
 	}
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/milosgajdos/netscrape/pkg/graph"
 	"github.com/milosgajdos/netscrape/pkg/query"
+	"github.com/milosgajdos/netscrape/pkg/uuid"
 )
 
 // Object is store object
@@ -35,10 +36,10 @@ type Store interface {
 	Graph(context.Context) (graph.Graph, error)
 	// Add Entity to store.
 	Add(context.Context, Entity, ...Option) error
-	// Link two entities in store
-	Link(ctx context.Context, from, to Entity, opts ...Option) error
+	// Link two entities in store.
+	Link(ctx context.Context, from, to uuid.UID, opts ...Option) error
 	// Delete Entity from store.
 	Delete(context.Context, Entity, ...Option) error
-	// Unlink two entities in store
-	Unlink(ctx context.Context, from, to Entity, opts ...Option) error
+	// Unlink two entities in store.
+	Unlink(ctx context.Context, from, to uuid.UID, opts ...Option) error
 }


### PR DESCRIPTION
Previously, in `netscrape`,  we would be building the graph/network and typecasting the `graph.Graph` handle into `NodeAdder` and `NodeLinker` before proceeding further. This PR removes this and relies on underlying `store` to do that for us.

This is semantically more correct and actually drasticallysimplifies the code.