### PR TITLE
Change graph.Graph and memory.Graph interfaces

### DIFF
--- a/netscrape.go
+++ b/netscrape.go
@@ -40,7 +40,7 @@ func New(opts ...Option) (*netscraper, error) {
 			return nil, err
 		}
 
-		s, err = memstore.New(g)
+		s, err = memstore.New(memstore.WithGraph(g))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -3,7 +3,6 @@ package graph
 import (
 	"context"
 
-	"github.com/milosgajdos/netscrape/pkg/query"
 	"github.com/milosgajdos/netscrape/pkg/space"
 	"github.com/milosgajdos/netscrape/pkg/uuid"
 	"gonum.org/v1/gonum/graph/encoding"
@@ -67,50 +66,18 @@ type DOTGraph interface {
 	DOT() (string, error)
 }
 
-// SubGrapher returns the maximum subgraph of a graph.
+// SubGrapher returns subgraph of a graph.
 type SubGrapher interface {
 	// SubGraph returns the maximum subgraph of a graph
 	// starting at node with given uid up to given depth.
 	SubGraph(ctx context.Context, uid uuid.UID, depth int, opts ...Option) (Graph, error)
 }
 
-// Querier queries graph.
-type Querier interface {
-	// Query the graph and return the results.
-	Query(context.Context, query.Query) ([]Object, error)
-}
-
-// NodeAdder adds nodes to graph.
-type NodeAdder interface {
-	// NewNode returns a new node.
-	NewNode(context.Context, space.Entity, ...Option) (Node, error)
-	// AddNode adds a new node to graph.
-	AddNode(context.Context, Node) error
-}
-
-// NodeRemover removes node from graph
-type NodeRemover interface {
-	// RemoveNode removes node from graph.
-	RemoveNode(context.Context, uuid.UID) error
-}
-
-// Linker links two nodes in graph.
-type Linker interface {
-	// Link links two nodes and returns the new edge.
-	Link(ctx context.Context, from, to uuid.UID, opts ...Option) (Edge, error)
-}
-
-// Unlinker removes link between two Nodes.
-type Unlinker interface {
-	// Unlink removes link from graph.
-	Unlink(ctx context.Context, from, to uuid.UID) error
-}
-
 // Graph is a graph of entities.
 type Graph interface {
 	// UID returns graph uid.
 	UID() uuid.UID
-	// Node returns node with given uid.
+	// Node returns the node with given uid.
 	Node(context.Context, uuid.UID) (Node, error)
 	// Nodes returns all graph nodes.
 	Nodes(context.Context) ([]Node, error)

--- a/pkg/graph/memory/memory.go
+++ b/pkg/graph/memory/memory.go
@@ -1,13 +1,56 @@
 package memory
 
-import "github.com/milosgajdos/netscrape/pkg/graph"
+import (
+	"context"
+
+	"github.com/milosgajdos/netscrape/pkg/graph"
+	"github.com/milosgajdos/netscrape/pkg/query"
+	"github.com/milosgajdos/netscrape/pkg/space"
+	"github.com/milosgajdos/netscrape/pkg/uuid"
+)
+
+// NOTE: this interface is a [temporary] hack!
+// Ideally, I would like to figure out how to parse
+// a generic GraphQL query into query.Query interface.
+// Or maybe graph.Query should simply accept a string,
+// which would then be parsed into query.Query.
+type Querier interface {
+	// Query the graph and return the results.
+	Query(context.Context, query.Query) ([]graph.Object, error)
+}
+
+// NodeAdder adds nodes to graph.
+type NodeAdder interface {
+	// NewNode returns a new node.
+	NewNode(context.Context, space.Entity, ...graph.Option) (graph.Node, error)
+	// AddNode adds a new node to graph.
+	AddNode(context.Context, graph.Node) error
+}
+
+// NodeRemover removes node from graph
+type NodeRemover interface {
+	// RemoveNode removes node from graph.
+	RemoveNode(context.Context, uuid.UID) error
+}
+
+// Linker links two nodes in graph.
+type Linker interface {
+	// Link links two nodes and returns the new edge.
+	Link(ctx context.Context, from, to uuid.UID, opts ...graph.Option) (graph.Edge, error)
+}
+
+// Unlinker removes link between two Nodes.
+type Unlinker interface {
+	// Unlink removes the link between the nodes with given UIDs from graph.
+	Unlink(ctx context.Context, from, to uuid.UID) error
+}
 
 // Graph is in-memory graph.
 type Graph interface {
 	graph.Graph
 	graph.SubGrapher
-	graph.NodeAdder
-	graph.NodeRemover
-	graph.Linker
-	graph.Unlinker
+	NodeAdder
+	NodeRemover
+	Linker
+	Unlinker
 }

--- a/pkg/graph/memory/wug.go
+++ b/pkg/graph/memory/wug.go
@@ -314,6 +314,7 @@ func (g *WUG) SubGraph(ctx context.Context, uid uuid.UID, depth int, opts ...gra
 }
 
 // queryEdge returns all the edges that match given query
+// TODO: find edges with given UID
 func (g WUG) queryEdge(q query.Query) ([]graph.Edge, error) {
 	traversed := make(map[string]bool)
 

--- a/pkg/store/memory/memory.go
+++ b/pkg/store/memory/memory.go
@@ -18,8 +18,14 @@ type Store struct {
 }
 
 // New creates a new in-memory store backed by graph g and returns it.
-// If g is nil, the store creates *memory.WUG with default options.
-func New(g memory.Graph) (*Store, error) {
+// By default store uses memory.WUG unless overridden by WithGraph options.
+func New(opts ...Option) (*Store, error) {
+	gopts := Options{}
+	for _, apply := range opts {
+		apply(&gopts)
+	}
+
+	g := gopts.Graph
 	if g == nil {
 		var err error
 		g, err = memory.NewWUG()
@@ -93,7 +99,7 @@ func (m *Store) Unlink(ctx context.Context, from, to uuid.UID, opts ...store.Opt
 
 // Query queries the store and returns the results.
 func (m Store) Query(ctx context.Context, q query.Query) ([]store.Entity, error) {
-	g, ok := m.g.(graph.Querier)
+	g, ok := m.g.(memory.Querier)
 	if !ok {
 		return nil, fmt.Errorf("query: %w", graph.ErrUnsupported)
 	}

--- a/pkg/store/memory/memory_test.go
+++ b/pkg/store/memory/memory_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	m, err := New(nil)
+	m, err := New()
 	if err != nil {
 		t.Fatalf("failed to create store: %v", err)
 	}
@@ -23,7 +23,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestAddDelete(t *testing.T) {
-	m, err := New(nil)
+	m, err := New()
 	if err != nil {
 		t.Fatalf("failed to create store: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestAddDelete(t *testing.T) {
 }
 
 func TestLink(t *testing.T) {
-	m, err := New(nil)
+	m, err := New()
 	if err != nil {
 		t.Fatalf("failed to create store: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestLink(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	m, err := New(nil)
+	m, err := New()
 	if err != nil {
 		t.Fatalf("failed to create store: %v", err)
 	}

--- a/pkg/store/memory/options.go
+++ b/pkg/store/memory/options.go
@@ -1,0 +1,29 @@
+package memory
+
+import (
+	"github.com/milosgajdos/netscrape/pkg/graph/memory"
+	"github.com/milosgajdos/netscrape/pkg/uuid"
+)
+
+// Options are graph options.
+type Options struct {
+	UID   uuid.UID
+	Graph memory.Graph
+}
+
+// Option configures Options.
+type Option func(*Options)
+
+// WithUID sets UID Options.
+func WithUID(u uuid.UID) Option {
+	return func(o *Options) {
+		o.UID = u
+	}
+}
+
+// WithGraph sets Graph options.
+func WithGraph(g memory.Graph) Option {
+	return func(o *Options) {
+		o.Graph = g
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -23,8 +23,8 @@ type Entity interface {
 // Store must provide query capabilities by default.
 // Ideally, I would like to figure out how to parse
 // a generic GraphQL query into query.Query interface.
-// Or maybe store.Query should simply accept string,
-// which would then have to be parsed into query.Query.
+// Or maybe store.Query should simply accept a string,
+// which would then be parsed into query.Query.
 type Querier interface {
 	// Query store and return the results.
 	Query(context.Context, query.Query) ([]Entity, error)
@@ -36,10 +36,10 @@ type Store interface {
 	Graph(context.Context) (graph.Graph, error)
 	// Add Entity to store.
 	Add(context.Context, Entity, ...Option) error
-	// Link two entities in store.
-	Link(ctx context.Context, from, to uuid.UID, opts ...Option) error
 	// Delete Entity from store.
 	Delete(context.Context, Entity, ...Option) error
+	// Link two entities in store.
+	Link(ctx context.Context, from, to uuid.UID, opts ...Option) error
 	// Unlink two entities in store.
 	Unlink(ctx context.Context, from, to uuid.UID, opts ...Option) error
 }


### PR DESCRIPTION
* most of the `graph` package interfaces have now been moved to memory package and are used to defined `memory.Graph` interface.
* `memory.Graph` can now be passed as an option to `memory.Store`