### PR TITLE
Allow to create entities without resources.

### DIFF
--- a/pkg/space/entity/entity.go
+++ b/pkg/space/entity/entity.go
@@ -21,10 +21,6 @@ type Entity struct {
 
 // New creates a new entity and returns it.
 func New(name, ns string, res space.Resource, opts ...Option) (*Entity, error) {
-	if res == nil {
-		return nil, ErrMissingResource
-	}
-
 	eopts := Options{}
 	for _, apply := range opts {
 		apply(&eopts)
@@ -50,12 +46,15 @@ func New(name, ns string, res space.Resource, opts ...Option) (*Entity, error) {
 
 	dotid := eopts.DOTID
 	if dotid == "" {
-		dotid = strings.Join([]string{
-			res.Group(),
-			res.Version(),
-			res.Kind(),
-			ns,
-			name}, "/")
+		dotid = uid.Value()
+		if res != nil {
+			dotid = strings.Join([]string{
+				res.Group(),
+				res.Version(),
+				res.Kind(),
+				ns,
+				name}, "/")
+		}
 	}
 
 	return &Entity{

--- a/pkg/space/entity/entity_test.go
+++ b/pkg/space/entity/entity_test.go
@@ -15,10 +15,10 @@ const (
 	resGroup   = "nodeResGroup"
 	resVersion = "nodeResVersion"
 	resKind    = "nodeResKind"
-	objUID     = "testID"
-	objName    = "testName"
-	objNs      = "testNs"
-	dotid      = "dotID"
+	entUID     = "testID"
+	entName    = "testName"
+	entNs      = "testNs"
+	entDOTID   = "dotID"
 )
 
 func newTestResource(name, group, version, kind string, namespaced bool, opts ...resource.Option) (space.Resource, error) {
@@ -31,21 +31,25 @@ func TestNew(t *testing.T) {
 		t.Fatalf("failed creating test resource: %v", err)
 	}
 
-	e, err := New(objName, objNs, r)
+	e, err := New(entName, entNs, r)
 	if err != nil {
 		t.Fatalf("failed creating new entity: %v", err)
 	}
 
-	if e.Name() != objName {
-		t.Errorf("expected name: %s, got: %s", objName, e.Name())
+	if e.Name() != entName {
+		t.Errorf("expected name: %s, got: %s", entName, e.Name())
 	}
 
-	if e.Namespace() != objNs {
-		t.Errorf("expected namespace: %s, got: %s", objNs, e.Namespace())
+	if e.Namespace() != entNs {
+		t.Errorf("expected namespace: %s, got: %s", entNs, e.Namespace())
 	}
 
 	if !reflect.DeepEqual(e.Resource(), r) {
 		t.Errorf("expected resource: %v, got: %v", r, e.Resource())
+	}
+
+	if _, err = New(entName, entNs, nil); err != nil {
+		t.Fatalf("failed creating new entity: %v", err)
 	}
 }
 
@@ -55,22 +59,22 @@ func TestNewWithOptions(t *testing.T) {
 		t.Fatalf("failed creating test resource: %v", err)
 	}
 
-	uid, err := uuid.NewFromString(objUID)
+	uid, err := uuid.NewFromString(entUID)
 	if err != nil {
 		t.Errorf("failed to create new uid: %v", err)
 	}
 
-	e, err := New(objName, objNs, r, WithUID(uid), WithDOTID(dotid))
+	e, err := New(entName, entNs, r, WithUID(uid), WithDOTID(entDOTID))
 	if err != nil {
 		t.Fatalf("failed creating new entity: %v", err)
 	}
 
-	if e.UID().Value() != objUID {
-		t.Errorf("expected entity uid: %s, got: %s", objUID, e.UID().Value())
+	if e.UID().Value() != entUID {
+		t.Errorf("expected entity uid: %s, got: %s", entUID, e.UID().Value())
 	}
 
-	if d := e.DOTID(); d != dotid {
-		t.Errorf("expected dotid: %s, got: %s", dotid, d)
+	if d := e.DOTID(); d != entDOTID {
+		t.Errorf("expected dotid: %s, got: %s", entDOTID, d)
 	}
 
 	dotid2 := "dotid2"
@@ -87,7 +91,7 @@ func TestNewWithOptions(t *testing.T) {
 	k, v := "foo", "bar"
 	a.Set(k, v)
 
-	e, err = New(objName, objNs, r, WithAttrs(a))
+	e, err = New(entName, entNs, r, WithAttrs(a))
 	if err != nil {
 		t.Errorf("failed to create new entity: %v", err)
 	}

--- a/pkg/space/resource/options.go
+++ b/pkg/space/resource/options.go
@@ -11,6 +11,8 @@ type Options struct {
 	UID uuid.UID
 	// Attrs options
 	Attrs attrs.Attrs
+	// DOTID options
+	DOTID string
 }
 
 // Option configures Options.
@@ -27,5 +29,12 @@ func WithAttrs(a attrs.Attrs) Option {
 func WithUID(u uuid.UID) Option {
 	return func(o *Options) {
 		o.UID = u
+	}
+}
+
+// WithDOTID sets Attrs options
+func WithDOTID(d string) Option {
+	return func(o *Options) {
+		o.DOTID = d
 	}
 }

--- a/pkg/space/resource/resource.go
+++ b/pkg/space/resource/resource.go
@@ -45,10 +45,13 @@ func New(name, group, version, kind string, namespaced bool, opts ...Option) (*R
 		}
 	}
 
-	dotid := strings.Join([]string{
-		group,
-		version,
-		kind}, "/")
+	dotid := ropts.DOTID
+	if dotid == "" {
+		dotid = strings.Join([]string{
+			group,
+			version,
+			kind}, "/")
+	}
 
 	return &Resource{
 		uid:        uid,

--- a/pkg/space/resource/resource_test.go
+++ b/pkg/space/resource/resource_test.go
@@ -4,40 +4,43 @@ import (
 	"testing"
 
 	"github.com/milosgajdos/netscrape/pkg/attrs"
+	"github.com/milosgajdos/netscrape/pkg/uuid"
 )
 
 const (
-	name    = "ResName"
-	group   = "ResGroup"
-	version = "ResVersion"
-	kind    = "ResKind"
-	ns      = false
+	testUID     = "resUID"
+	testName    = "ResName"
+	testGroup   = "ResGroup"
+	testVersion = "ResVersion"
+	testKind    = "ResKind"
+	testNs      = false
+	testDOTID   = "dotID"
 )
 
 func TestNew(t *testing.T) {
-	r, err := New(name, group, version, kind, ns)
+	r, err := New(testName, testGroup, testVersion, testKind, testNs)
 	if err != nil {
 		t.Fatalf("failed creating new resource: %v", err)
 	}
 
-	if n := r.Name(); n != name {
-		t.Errorf("expected name: %s, got: %s", name, n)
+	if n := r.Name(); n != testName {
+		t.Errorf("expected name: %s, got: %s", testName, n)
 	}
 
-	if g := r.Group(); g != group {
-		t.Errorf("expected group: %s, got: %s", group, g)
+	if g := r.Group(); g != testGroup {
+		t.Errorf("expected group: %s, got: %s", testGroup, g)
 	}
 
-	if v := r.Version(); v != version {
-		t.Errorf("expected version: %s, got: %s", version, v)
+	if v := r.Version(); v != testVersion {
+		t.Errorf("expected version: %s, got: %s", testVersion, v)
 	}
 
-	if k := r.Kind(); k != kind {
-		t.Errorf("expected kind: %s, got: %s", kind, k)
+	if k := r.Kind(); k != testKind {
+		t.Errorf("expected kind: %s, got: %s", testKind, k)
 	}
 
-	if n := r.Namespaced(); n != ns {
-		t.Errorf("expected namespaced: %v, got: %v", ns, n)
+	if n := r.Namespaced(); n != testNs {
+		t.Errorf("expected namespaced: %v, got: %v", testNs, n)
 	}
 }
 
@@ -49,12 +52,25 @@ func TestNewWithOptions(t *testing.T) {
 	k, v := "foo", "bar"
 	a.Set(k, v)
 
-	r, err := New(name, group, version, kind, ns, WithAttrs(a))
+	uid, err := uuid.NewFromString(testUID)
+	if err != nil {
+		t.Errorf("failed to create new uid: %v", err)
+	}
+
+	r, err := New(testName, testGroup, testVersion, testKind, testNs, WithUID(uid), WithDOTID(testDOTID), WithAttrs(a))
 	if err != nil {
 		t.Fatalf("failed creating new resource: %v", err)
 	}
 
 	if val := r.Attrs().Get(k); val != v {
 		t.Errorf("expected attrs val: %s, for key: %s, got: %s", v, k, val)
+	}
+
+	if u := r.UID().Value(); u != testUID {
+		t.Errorf("expected resource uid: %s, got: %s", testUID, u)
+	}
+
+	if d := r.DOTID(); d != testDOTID {
+		t.Errorf("expected dotid: %s, got: %s", testDOTID, d)
 	}
 }


### PR DESCRIPTION
If the entity doesnt have any resource its DOTID is configued
to be its UID if no specific DOTID options have been provided.
Make DOTID for Resource configurable.
Add more tests.